### PR TITLE
Allows deleting previous slugs + fixes slug field conflict with slug …

### DIFF
--- a/src/backend/controllers/ContentSourceController.php
+++ b/src/backend/controllers/ContentSourceController.php
@@ -902,6 +902,14 @@ class ContentSourceController extends Controller
                     $slug->save();
                 }
             }
+            if(isset($_POST['RemoveSlug'])){
+                $slugs = $model->getOldSlugs(Yii::$app->language);
+                foreach ($slugs as $old_slug){
+                    if(in_array($old_slug->id,$_POST['RemoveSlug'])){
+                        $old_slug->delete();
+                    }
+                }
+            }
             if (Model::loadMultiple($components, $_POST))
             {
                 /** @var ContentComponent $component */

--- a/src/backend/views/content-source/update.php
+++ b/src/backend/views/content-source/update.php
@@ -228,21 +228,21 @@ $form                            = ActiveForm::begin([
             ]);
 
             $slugs = $model->getOldSlugs(Yii::$app->language);
-
+            $label = Yii::t('backend', 'Previous Slugs');
             foreach ($slugs as $slug) {
-
-                echo $form->field($slug, 'slug')
-                    ->widget(MultipleInput::className())
-
-                    ->textInput([
-                        'placeholder' => $slug->slug,
-                        'readonly' => true,
-                        'options' => [
-                            'style' => 'width: 250px;',
-                        ],
-                    ])->label($label);
-
-                if (next($slugs) == false) { $label = 'Current Slug: '; }else{ $label = ''; }
+                $lastSlug = end($slugs)->id === $slug->id;
+                if($lastSlug){
+                    $label = Yii::t('backend', 'Current Slug');
+                }
+                echo Html::label($label);
+                echo '<pre>'.$slug->slug.'</pre>';
+                if(!$lastSlug){
+                    echo Html::checkbox('RemoveSlug[]',false,array('value' => $slug->id));
+                    echo '&nbsp;&nbsp;'.Yii::t('backend', 'Remove Slug').' ?';
+                    echo '<br/>';
+                    echo '<br/>';
+                }
+                $label =  '';
             }
 
             BoxPanel::end();


### PR DESCRIPTION
On this PR: 

**Fixes slug field conflict with slug history display**
There was a conflict because the slug history was displayed using input fields, leading to a double submission of the slug.

**Allows deleting previous slugs**
User can delete previous slugs, reducing the amount of redirections to be calculated and freeing a slug to be used by other content source